### PR TITLE
Make man page generation generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Makefile.in
 *.lo
 *.la
 *~
+*.[1-9]
 
 /aclocal.m4
 /autom4te.cache/

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,11 +8,14 @@ dist_man_MANS = vmod_example.3
 MAINTAINERCLEANFILES = $(dist_man_MANS)
 
 vmod_example.3: README.rst
+
+%.1 %.2 %.3 %.4 %.5 %.6 %.7 %.8 %.9:
 if HAVE_RST2MAN
-	${RST2MAN} README.rst $@
+	${RST2MAN} $< $@
 else
 	@echo "========================================"
 	@echo "You need rst2man installed to make dist"
 	@echo "========================================"
 	@false
 endif
+


### PR DESCRIPTION
The creation of vmod_example.3 man page from README.rst is currently
hard-coded. I'v made it possible to generate any man page against any rst
template. Man pages are also ignored, instead of leaving the repository
in a dirty state.
