### PR TITLE
define PKG_CHECK_VAR if it doesn't exist

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,24 @@ AM_CONDITIONAL(HAVE_RST2MAN, [test "x$RST2MAN" != "xno"])
 AC_HEADER_STDC
 AC_CHECK_HEADERS([sys/stdlib.h])
 
+# backwards compat with older pkg-config
+# - pull in AC_DEFUN from pkg.m4
+m4_ifndef([PKG_CHECK_VAR], [
+# PKG_CHECK_VAR(VARIABLE, MODULE, CONFIG-VARIABLE,
+# [ACTION-IF-FOUND], [ACTION-IF-NOT-FOUND])
+# -------------------------------------------
+# Retrieves the value of the pkg-config variable for the given module.
+AC_DEFUN([PKG_CHECK_VAR],
+[AC_REQUIRE([PKG_PROG_PKG_CONFIG])dnl
+AC_ARG_VAR([$1], [value of $3 for $2, overriding pkg-config])dnl
+
+_PKG_CONFIG([$1], [variable="][$3]["], [$2])
+AS_VAR_COPY([$1], [pkg_cv_][$1])
+
+AS_VAR_IF([$1], [""], [$5], [$4])dnl
+])# PKG_CHECK_VAR
+])
+
 PKG_CHECK_MODULES([libvarnishapi], [varnishapi])
 PKG_CHECK_VAR([LIBVARNISHAPI_DATAROOTDIR], [varnishapi], [datarootdir])
 PKG_CHECK_VAR([LIBVARNISHAPI_BINDIR], [varnishapi], [bindir])

--- a/src/vmod_example.vcc
+++ b/src/vmod_example.vcc
@@ -1,4 +1,15 @@
+#
+# your
+# Copyright (c) 1900-1901 by no-one
+#
+# goes here. vmodtool requires this format
+#
+
 $Module example 3 Example VMOD
+
+DESCRIPTION
+===========
+
 This is the embedded documentation for the example VMOD. It should
 mention what the vmod is intended to do.
 


### PR DESCRIPTION
this avoids problems with outdated versions of pkg.m4