### PR TITLE
construct PATH containing the varnishd we are configured for

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -27,7 +27,8 @@ VMOD_TESTS = $(top_srcdir)/src/tests/*.vtc
 .PHONY: $(VMOD_TESTS) vcc
 
 $(top_srcdir)/src/tests/*.vtc: libvmod_example.la
-	@VARNISHTEST@ -Dvarnishd=@VARNISHD@ -Dvmod_topbuild=$(abs_top_builddir) $@
+	PATH=@LIBVARNISHAPI_SBINDIR@:$$PATH \
+	@VARNISHTEST@ -Dvmod_topbuild=$(abs_top_builddir) $@
 
 check: $(VMOD_TESTS)
 


### PR DESCRIPTION
This is required since master commit 0a05e52c9c84ac4eca5d5049bf02954d1ec1dba3
