### PR TITLE
Fixing 'Example' replacements on the rename script

### DIFF
--- a/rename-vmod-script
+++ b/rename-vmod-script
@@ -27,7 +27,7 @@ git mv src/vmod_example.c src/vmod_${NAME}.c
 git mv src/vmod_example.vcc src/vmod_${NAME}.vcc
 git mv vmod-example.spec vmod-${NAME}.spec
 
-git grep -z -l example | xargs -0 sed -i -s -e "s/example/${NAME}/g"
+git grep -z -l example | xargs -0 sed -i -s -e "s/[Ee]xample/${NAME}/g"
 
 git rm -f rename-vmod-script
 


### PR DESCRIPTION
Watched a VMOD talk in the Varnish Summit SF, apparently there was a small issue with the renaming script. This might help with it. I didn't test it thoroughly but it worked for me.

Before the change, after renaming 'example' to 'goodrexeg' : 

```
$ grep -R -P '[Ee]xample' *
README.rst:Varnish Example Module
README.rst:Example Varnish vmod demonstrating how to write an out-of-tree Varnish vmod.
README.rst:Example
debian/control:Description: Example vmod for Varnish
src/vmod_goodregex.vcc:$Module goodregex 3 Example VMOD
vmod-goodregex.spec:Summary: Example VMOD for Varnish
vmod-goodregex.spec:Example VMOD
$
```

After the change : 

```
$ grep -R -P '[Ee]xample' *
$
```

Feel free to close the Pull request if you have another solution, no feelings will be hurt but if it helps, glad it did!

Regards,
Samir
